### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.katomic.json
+++ b/org.kde.katomic.json
@@ -17,6 +17,9 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
+        "/share/doc",
         "/share/qlogging-categories6"
     ],
     "modules": [


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

This PR also removes the /share/carddecks folder, which is not required for this game.